### PR TITLE
Changing the length limitation on auto-generated class names

### DIFF
--- a/Core/StorEvil/CodeGeneration/TestFixtureClassGenerator.cs
+++ b/Core/StorEvil/CodeGeneration/TestFixtureClassGenerator.cs
@@ -1,4 +1,5 @@
-﻿using System.Linq;
+﻿using System;
+using System.Linq;
 using System.Text;
 using StorEvil.Core;
 using StorEvil.Utility;
@@ -11,6 +12,11 @@ namespace StorEvil.CodeGeneration
         {
             var stringBuilder = new StringBuilder();
             string fixtureName = GetFixtureName(story);
+
+#if DEBUG
+            System.Diagnostics.EventLog.WriteEntry("StorEvil", String.Concat("Generated Fixture Name: ", fixtureName));
+#endif
+
             stringBuilder.Append("namespace " + defaultNamespace + "{");
             var categories = string.Join("", (story.Tags ?? new string[0]).Select(t => string.Format(@"[Category(""{0}"")]", t)).ToArray());
             stringBuilder.AppendLine(categories);

--- a/Core/StorEvil/Parsing/StoryParser.cs
+++ b/Core/StorEvil/Parsing/StoryParser.cs
@@ -155,7 +155,7 @@ namespace StorEvil.Parsing
             if (_storyId == null)
                 _storyId = Guid.NewGuid().ToString();
 
-            var id = _storyId.Length < 120 ? _storyId : _storyId.Substring(0, 120);
+            var id = _storyId.Length <= 512 ? _storyId : _storyId.Substring(0, 512);
             return new Story(id, _storyName.ToString().Trim(), _scenarios) {Tags = _storyTags, Location = _storyLocation};
         }
 

--- a/Core/StorEvil/Utility/StringUtility.cs
+++ b/Core/StorEvil/Utility/StringUtility.cs
@@ -24,7 +24,7 @@ namespace StorEvil.Utility
 
         public static string ToCSharpName(this string s)
         {
-            var chars = s                
+            var chars = s
                 .Replace(' ', '_')
                 .ToCharArray()
                 .Where(c => char.IsLetterOrDigit(c) | c == '_').ToArray();
@@ -40,7 +40,7 @@ namespace StorEvil.Utility
                 .Select(c => char.IsLetterOrDigit(c) ? c : '_').ToArray();
 
             var name =  EnsureFirstCharacterLegal(chars);
-            return name.Length > 100 ? name.Substring(0, 100) : name;
+            return name.Length > 512 ? name.Substring(0, 512) : name;
         }
 
         private static string EnsureFirstCharacterLegal(char[] chars)

--- a/Examples/Tutorial.NUnit/Generated.cs
+++ b/Examples/Tutorial.NUnit/Generated.cs
@@ -40,34 +40,34 @@ namespace StorEvilSpecs{
   [NUnit.Framework.TestAttribute] public void An_ambiguous_match() {
 #line 1  "AmbiguousMatches.feature"
 #line hidden
-#line 5
+#line 11
 ExecuteLine(@"using foo context");
 #line hidden
 
-#line 6
+#line 13
 ExecuteLine(@"call an ambiguous method");
 #line hidden
 
-#line 7
+#line 14
 ExecuteLine(@"method on foo should have been called");
 #line hidden
   }
   [NUnit.Framework.TestAttribute] public void An_ambiguous_match_where_both_are_called() {
 #line 1  "AmbiguousMatches.feature"
 #line hidden
-#line 10
+#line 18
 ExecuteLine(@"using foo context");
 #line hidden
 
-#line 11
+#line 20
 ExecuteLine(@"using bar context");
 #line hidden
 
-#line 12
+#line 22
 ExecuteLine(@"call an ambiguous method");
 #line hidden
 
-#line 13
+#line 23
 ExecuteLine(@"method on bar should have been called");
 #line hidden
   }
@@ -87,22 +87,22 @@ namespace StorEvilSpecs{
   [NUnit.Framework.TestAttribute] public void Background_run_count_should_be_1() {
 #line 1  "Background.feature"
 #line hidden
-#line 4
+#line 6
 ExecuteLine(@"Run the background");
 #line hidden
 
-#line 7
+#line 9
 ExecuteLine(@"Background run count should be 1");
 #line hidden
   }
   [NUnit.Framework.TestAttribute] public void Background_run_count_should_be_2() {
 #line 1  "Background.feature"
 #line hidden
-#line 4
+#line 6
 ExecuteLine(@"Run the background");
 #line hidden
 
-#line 10
+#line 12
 ExecuteLine(@"Background run count should be 2");
 #line hidden
   }
@@ -122,59 +122,56 @@ namespace StorEvilSpecs{
   [NUnit.Framework.TestAttribute] public void basic_matching_of_plaintext_line() {
 #line 1  "BasicGrammar.feature"
 #line hidden
-#line 6
+#line 9
 ExecuteLine(@"When my name is StorEvil");
 #line hidden
   }
   [NUnit.Framework.TestAttribute] public void a_basic_assertion() {
 #line 1  "BasicGrammar.feature"
 #line hidden
-#line 9
+#line 15
 ExecuteLine(@"When my name is StorEvil");
 #line hidden
 
-#line 10
+#line 16
 ExecuteLine(@"I should eat all other BDD frameworks");
 #line hidden
   }
   [NUnit.Framework.TestAttribute] public void assertion_using_the_ShouldXXX_methods() {
 #line 1  "BasicGrammar.feature"
 #line hidden
-#line 13
+#line 19
 ExecuteLine(@"When my name is StorEvil");
 #line hidden
 
-#line 14
+#line 20
 ExecuteLine(@"All other BDD frameworks are eaten should be true");
 #line hidden
   }
   [NUnit.Framework.TestAttribute] public void parameterizing_and_adding_a_basic_assertion() {
 #line 1  "BasicGrammar.feature"
 #line hidden
-#line 17
+#line 23
 ExecuteLine(@"When my name is ""Some other BDD framework""");
 #line hidden
 
-#line 18
+#line 24
 ExecuteLine(@"All other BDD frameworks are eaten should be false");
 #line hidden
   }
   [NUnit.Framework.TestAttribute] public void matching_with_an_integer_parameter_in_the_middle() {
 #line 1  "BasicGrammar.feature"
 #line hidden
-#line 21
+#line 27
 ExecuteLine(@"Given I am 42 years old");
 #line hidden
 
-#line 22
+#line 28
 ExecuteLine(@"My age in one year should be 43");
 #line hidden
   }
-  [NUnit.Framework.TestAttribute] public void loading_config_values() {
+  [NUnit.Framework.TestAttribute] public void An_outline_is_a_scenario_that_is_run_once_for_each_example() {
 #line 1  "BasicGrammar.feature"
-#line hidden
-#line 25
-ExecuteLine(@"The configvalue should be storevil");
 #line hidden
   }
   }
@@ -226,11 +223,11 @@ namespace StorEvilSpecs{
   [NUnit.Framework.TestAttribute] public void custom_float_conversion() {
 #line 1  "CustomParameterConversion.feature"
 #line hidden
-#line 4
+#line 7
 ExecuteLine(@"We can parse floats like 3.14159265");
 #line hidden
 
-#line 5
+#line 8
 ExecuteLine(@"and the result should be between 3.14 and 3.15");
 #line hidden
   }
@@ -247,10 +244,14 @@ namespace StorEvilSpecs{
     public void HandleTearDown() { base.AfterEach(); }
     [NUnit.Framework.TestFixtureTearDownAttribute]
     public void HandleTestFixtureTearDown() { base.AfterAll(); }
+  [NUnit.Framework.TestAttribute] public void An_example_is_a_parameterized_scenario_that_is_run_once_for_each_example_row() {
+#line 1  "Tables.feature"
+#line hidden
+  }
   [NUnit.Framework.TestAttribute] public void A_table_of_data_can_map_to_a_string____() {
 #line 1  "Tables.feature"
 #line hidden
-#line 17
+#line 37
 ExecuteLine(@"Given the following competition groups:
 | South Africa| Mexico    | Uruguay     | France   |
 | Argentina   | Nigeria   | South Korea | Greece   |
@@ -258,18 +259,18 @@ ExecuteLine(@"Given the following competition groups:
 | Germany     | Australia | Serbia      | Ghana    |");
 #line hidden
 
-#line 23
+#line 43
 ExecuteLine(@"Then there should be 4 groups");
 #line hidden
 
-#line 24
+#line 44
 ExecuteLine(@"And USA and England should be in the same group");
 #line hidden
   }
   [NUnit.Framework.TestAttribute] public void A_table_of_data_that_maps_to_an_array_of_types() {
 #line 1  "Tables.feature"
 #line hidden
-#line 28
+#line 48
 ExecuteLine(@"Given the following teams:
 | Rank | Nation      | Region       |
 | 1    | Spain       | Europe       |
@@ -278,74 +279,74 @@ ExecuteLine(@"Given the following teams:
 | 4    | Italy       | Europe       |");
 #line hidden
 
-#line 35
+#line 55
 ExecuteLine(@"Then there should be 4 teams");
 #line hidden
 
-#line 36
+#line 56
 ExecuteLine(@"and Spain should be ranked 1");
 #line hidden
 
-#line 37
+#line 57
 ExecuteLine(@"and Italy should be in Europe");
 #line hidden
 
-#line 38
+#line 58
 ExecuteLine(@"and Brazil should be ranked 2");
 #line hidden
   }
   [NUnit.Framework.TestAttribute] public void Setting_attributes_of_a_single_instance_of_any_type() {
 #line 1  "Tables.feature"
 #line hidden
-#line 42
+#line 62
 ExecuteLine(@"Given the following team:
 | Rank	 | 18           |
 | Nation | USA          |
 | Region | NorthAmerica |");
 #line hidden
 
-#line 47
+#line 67
 ExecuteLine(@"And the following team:
 | Rank	 | 39           |
 | Nation | Ireland      |
 | Region | Europe       |");
 #line hidden
 
-#line 52
+#line 72
 ExecuteLine(@"Then there should be 2 teams");
 #line hidden
 
-#line 53
+#line 73
 ExecuteLine(@"and USA should be ranked 18");
 #line hidden
 
-#line 54
+#line 74
 ExecuteLine(@"and Ireland should be in Europe");
 #line hidden
   }
   [NUnit.Framework.TestAttribute] public void Using_a_hash_table() {
 #line 1  "Tables.feature"
 #line hidden
-#line 58
+#line 78
 ExecuteLine(@"Given the following roster:
 | 7  | Beasley          |
 | 12 | Altidore         |
 | 1  | Howard           |");
 #line hidden
 
-#line 63
+#line 83
 ExecuteLine(@"Then there should be 3 players");
 #line hidden
 
-#line 64
+#line 84
 ExecuteLine(@"and Beasley should be number 7");
 #line hidden
 
-#line 65
+#line 85
 ExecuteLine(@"and Altidore should be number 12");
 #line hidden
 
-#line 66
+#line 86
 ExecuteLine(@"and Howard should be number 1");
 #line hidden
   }
@@ -353,7 +354,7 @@ ExecuteLine(@"and Howard should be number 1");
 }namespace StorEvilSpecs { [SetUpFixture] public class SetupAndTearDown {
   [SetUp] public void SetUp() {
     var assemblyRegistry = new StorEvil.Context.AssemblyRegistry( new System.Reflection.Assembly[] {
-typeof(Tutorial.BackgroundContext).Assembly
+typeof(Tutorial.FloatConverter).Assembly
     });
    var eh = new StorEvil.Interpreter.ExtensionMethodHandler(assemblyRegistry);
    // _sessionContext = new SessionContext();


### PR DESCRIPTION
- Changed the (arbitrary) class name limit on the auto-generated class names from 100/120 to 512 characters.
  Setting the limit at 512 characters was chosen due to a apparent limitation in the C# IDE, but as far as MSIL is concerned, there's no hard limit on the length of class names.
